### PR TITLE
Remove process.exit invocation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,10 +65,6 @@ class LairClient extends EventEmitter {
     super(options)
 
     const conn = net.createConnection(address)
-    conn.on('error', function (data) {
-      console.error(data)
-      process.exit(1)
-    })
 
     let connected
     this._connect_promise = new Promise((f, r) => {


### PR DESCRIPTION
I was using `LairClient.connect` in a test where I wanted to run cleanup code if it failed. Because of this call to process.exit, my cleanup code was not being run.